### PR TITLE
Stops matching quotes that have thanks; Added Thx as keyword

### DIFF
--- a/bot/src/config/config.ts
+++ b/bot/src/config/config.ts
@@ -36,5 +36,5 @@ export const config: BotConfig = {
     '711254277141561375': 5,
     'thanks': 10,
   },
-  thanksKeywords: ["thanks", "thank", "thunk", "kudos"],
+  thanksKeywords: ["thank","thunk","thx","kudo"],
 };

--- a/bot/src/config/config.ts
+++ b/bot/src/config/config.ts
@@ -36,5 +36,5 @@ export const config: BotConfig = {
     '711254277141561375': 5,
     'thanks': 10,
   },
-  thanksKeywords: ["thank","thunk","thx","kudo"],
+  thanksKeywords: ["thanks","thunk","thx","kudo"],
 };

--- a/bot/src/utils/points_handler.ts
+++ b/bot/src/utils/points_handler.ts
@@ -21,10 +21,16 @@ export class PointsHandler {
     if (message.author.bot || this.isCommand(message)) {
       return;
     }
-
-    if (config.thanksKeywords.some((t) =>
-      message.content.toLowerCase().includes(t)
-    )) {
+    
+    /*
+     * Test if any line converted to lowercase matches
+     * one of the keywords and doesn't start with >
+     */
+    if (
+      new RegExp(
+        `^[^\n>]*(${config.thanksKeywords.join('|')})`,
+        'gmi').test(message.content)
+    ) {
       //  Thanks message
       this.handleThanks(message);
     } else {


### PR DESCRIPTION
* Added thx to keywords config list.
* Use regex to ensure the thank wasn't from a quoted message
`/^[^>\n]*(thank|thunk|thx|kudo)/gmi`